### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for this repository
+# The admin team is required to review and approve all pull requests
+
+# Default owners for everything in the repo
+* @modelcontextprotocol-security/SecurityGuidanceAdmin


### PR DESCRIPTION
This PR adds a CODEOWNERS file to designate the appropriate admin team as code owners.

The admin team will be automatically requested to review all pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)